### PR TITLE
credit card payment - use payment type 'debit' instead of 'registration'

### DIFF
--- a/Action/Api/HeidelpayCreditCardCaptureAction.php
+++ b/Action/Api/HeidelpayCreditCardCaptureAction.php
@@ -33,7 +33,7 @@ class HeidelpayCreditCardCaptureAction implements ActionInterface, GatewayAwareI
         $protocol = stripos($_SERVER['SERVER_PROTOCOL'],'https') === true ? 'https://' : 'http://';
 
         //TODO: Add options here
-        $request->getApi()->getApi()->registration(
+        $request->getApi()->getApi()->debit(
             $protocol . $_SERVER['HTTP_HOST'],
             'FALSE'
         );


### PR DESCRIPTION
Payment type registration only transmits account data to heidelpay for deferred charging or recurring payments.
By default credit card should be charged directly.